### PR TITLE
Mark Codex releases as prereleases

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -243,12 +243,26 @@ jobs:
          FILE_TIME=$(echo $FILENAME | grep -oE '[0-9]{8,}' | head -n 1)
          echo "DATE=$FILE_TIME" >> $GITHUB_ENV
 
+     - name: Set release metadata
+       run: |
+         if [[ "${{ inputs.build_profile }}" == "codex" ]]; then
+           echo "RELEASE_TAG=${DATE}-CODEX" >> $GITHUB_ENV
+           echo "RELEASE_NAME=${DATE} CODEX" >> $GITHUB_ENV
+           echo "RELEASE_PRERELEASE=true" >> $GITHUB_ENV
+           echo "RELEASE_LATEST=false" >> $GITHUB_ENV
+         else
+           echo "RELEASE_TAG=${DATE}" >> $GITHUB_ENV
+           echo "RELEASE_NAME=${DATE}" >> $GITHUB_ENV
+           echo "RELEASE_PRERELEASE=false" >> $GITHUB_ENV
+           echo "RELEASE_LATEST=true" >> $GITHUB_ENV
+         fi
+
      - name: Generate changelog
        shell: bash
        run: |
          git fetch --tags
 
-         CURRENT_TAG="${DATE}"
+         CURRENT_TAG="${RELEASE_TAG}"
          PREV_TAG=$(git tag --sort=-creatordate | grep -vx "${CURRENT_TAG}" | head -n 1 || true)
 
          if [ -z "$PREV_TAG" ]; then
@@ -270,12 +284,12 @@ jobs:
      - name: Create Release
        uses: ncipollo/release-action@v1
        with:
-         tag: ${{ env.DATE }}
-         name: ${{ env.DATE }}
+         tag: ${{ env.RELEASE_TAG }}
+         name: ${{ env.RELEASE_NAME }}
          artifacts: "ROCKNIX-*"          # 업로드할 파일 패턴
          allowUpdates: true              # 같은 날짜에 다시 돌리면 덮어쓰기 허용
-         makeLatest: true                # 최신 릴리즈로 표시
-         prerelease: false               # 프리 릴리즈로 표시 (원하면 true로 변경)
+         makeLatest: ${{ env.RELEASE_LATEST }}
+         prerelease: ${{ env.RELEASE_PRERELEASE }}
          #body: "빌드완료"
          bodyFile: release_notes.md
          token: ${{ secrets.GH_PAT }}    # 토큰 사용


### PR DESCRIPTION
## Summary

- Keep standard releases unchanged.
- Give Codex builds a date-based tag such as 20260830-CODEX.
- Display the release title as 20260830 CODEX.
- Mark Codex releases as prereleases and prevent them from becoming the latest release.

This is a follow-up to #463 and targets UzuCore/ROCKNIXK only.