### PR TITLE
Append CODEX suffix to Codex release filenames

### DIFF
--- a/.github/workflows/build-aarch64-image.yml
+++ b/.github/workflows/build-aarch64-image.yml
@@ -34,6 +34,7 @@ jobs:
       PROJECT: ${{ inputs.PROJECT }}
       DEVICE: ${{ inputs.DEVICE }}
       CODEX_SUPPORT: ${{ inputs.CODEX_SUPPORT }}
+      CODEX_SUFFIX: ${{ inputs.CODEX_SUPPORT == 'yes' && '-CODEX' || '' }}
       ARCH: aarch64
       CACHE_KEY: ccache-aarch64-${{ inputs.DEVICE }}-image-${{ github.sha }}
       DISABLE_COLORS: yes
@@ -132,7 +133,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: ROCKNIX-image-${{ inputs.DEVICE }}-${{ env.DATE }}
+          name: ROCKNIX-image-${{ inputs.DEVICE }}-${{ env.DATE }}${{ env.CODEX_SUFFIX }}
           path: |
             target/ROCKNIX-*.img.gz
             target/ROCKNIX-*.img.gz.sha256
@@ -141,7 +142,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: ROCKNIX-update-${{ inputs.DEVICE }}-${{ env.DATE }}
+          name: ROCKNIX-update-${{ inputs.DEVICE }}-${{ env.DATE }}${{ env.CODEX_SUFFIX }}
           path: |
             target/ROCKNIX-*.tar
             target/ROCKNIX-*.tar.sha256

--- a/scripts/image
+++ b/scripts/image
@@ -111,6 +111,10 @@ if [ -n "${IMAGE_SUFFIX}" ]; then
   IMAGE_NAME="${IMAGE_NAME}-${IMAGE_SUFFIX}"
 fi
 
+if [ "${CODEX_SUPPORT}" = "yes" ]; then
+  IMAGE_NAME="${IMAGE_NAME}-CODEX"
+fi
+
 echo "${IMAGE_NAME}" >${BUILD}/BUILD_FILENAME
 
 # Setup fakeroot


### PR DESCRIPTION
Follow-up to #464. Codex image, update tar, and checksum filenames now include the -CODEX suffix, and the Actions artifact names match. Standard builds remain unchanged. This PR targets UzuCore/ROCKNIXK only.